### PR TITLE
Fix hero section width

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,7 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+  width: 100%;
+  margin: 0;
+  padding: 0;
 }
 
 main {


### PR DESCRIPTION
## Summary
- remove width restriction from root container to let hero span full width

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684de4dd7d388322a50592d4d9547e08