### PR TITLE
Update hero heading style

### DIFF
--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -3,16 +3,20 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  padding: 4rem 1rem;
-  text-align: center;
+  padding: 4rem;
+  text-align: left;
   min-height: 100vh;
 }
 
 .hero-title {
   font-size: 3rem;
   margin-bottom: 1rem;
+  background-color: #800020;
+  padding: 0.25em 0.5em;
+  border-radius: 0.25em;
+  color: #fff;
 }
 
 .hero-description {

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -11,7 +11,7 @@ export default function Hero() {
         muted
         playsInline
       />
-      <h1 className="hero-title">Welcome to Born Site</h1>
+      <h1 className="hero-title">COURSEBORN</h1>
       <p className="hero-description">Building modern applications with React and Vite.</p>
       <button className="hero-cta">Get Started</button>
     </section>


### PR DESCRIPTION
## Summary
- update hero title to "COURSEBORN"
- left-align and vertically center hero content
- style hero heading with burgundy background

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684de8003ae88322a26d21be5b2407de