### PR TITLE
Update hero title layout

### DIFF
--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -16,6 +16,7 @@
   background-color: #cb351d;
   padding: 0.25em 0.5em;
   color: #fff;
+  margin-left: 25%;
 }
 
 .hero-description {

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -11,7 +11,11 @@ export default function Hero() {
         muted
         playsInline
       />
-      <h1 className="hero-title">COURSEBORN</h1>
+      <h1 className="hero-title">
+        COURSE
+        <br />
+        BORN
+      </h1>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- split hero title onto two lines
- move hero title slightly toward the page center

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684dea5e52448322af3c76914cdf20d9