### PR TITLE
Add About section with CardSwap cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "framer-motion": "^12.18.1",
+        "gsap": "^3.13.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -1931,6 +1932,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/gsap": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.13.0.tgz",
+      "integrity": "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "framer-motion": "^12.18.1",
+    "gsap": "^3.13.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import Hero from './components/Hero.jsx'
+import About from './components/About.jsx'
 import Courses from './components/Courses.jsx'
 import './App.css'
 
@@ -6,6 +7,7 @@ export default function App() {
   return (
     <main>
       <Hero />
+      <About />
       <Courses />
     </main>
   )

--- a/src/components/About.css
+++ b/src/components/About.css
@@ -1,0 +1,28 @@
+.about {
+  width: 100%;
+  min-height: 60vh;
+  position: relative;
+  padding: 2rem 4rem;
+}
+
+.about-title {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.about-card {
+  background-size: cover;
+  background-position: center;
+}
+
+.about-card-1 {
+  background-image: url('https://placekitten.com/400/200');
+}
+
+.about-card-2 {
+  background-image: url('https://placekitten.com/401/200');
+}
+
+.about-card-3 {
+  background-image: url('https://placekitten.com/402/200');
+}

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,0 +1,15 @@
+import CardSwap, { Card } from './CardSwap.jsx'
+import './About.css'
+
+export default function About() {
+  return (
+    <section className="about" id="about">
+      <h2 className="about-title">О нашей школе</h2>
+      <CardSwap width={320} height={200} cardDistance={50} verticalDistance={60}>
+        <Card customClass="about-card about-card-1" />
+        <Card customClass="about-card about-card-2" />
+        <Card customClass="about-card about-card-3" />
+      </CardSwap>
+    </section>
+  )
+}

--- a/src/components/CardSwap.css
+++ b/src/components/CardSwap.css
@@ -1,0 +1,35 @@
+.card-swap-container {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  transform: translate(5%, 20%);
+  transform-origin: bottom right;
+
+  perspective: 900px;
+  overflow: visible;
+}
+
+.card {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border-radius: 12px;
+  border: 1px solid #fff;
+  background: #000;
+
+  transform-style: preserve-3d;
+  will-change: transform;
+  backface-visibility: hidden;
+}
+
+@media (max-width: 768px) {
+  .card-swap-container {
+    transform: scale(0.75) translate(25%, 25%);
+  }
+}
+
+@media (max-width: 480px) {
+  .card-swap-container {
+    transform: scale(0.55) translate(25%, 25%);
+  }
+}

--- a/src/components/CardSwap.jsx
+++ b/src/components/CardSwap.jsx
@@ -1,0 +1,225 @@
+import React, {
+  Children,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
+import gsap from "gsap";
+import "./CardSwap.css";
+
+export const Card = forwardRef(
+  ({ customClass, ...rest }, ref) => (
+    <div
+      ref={ref}
+      {...rest}
+      className={`card ${customClass ?? ""} ${rest.className ?? ""}`.trim()}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const makeSlot = (
+  i,
+  distX,
+  distY,
+  total
+) => ({
+  x: i * distX,
+  y: -i * distY,
+  z: -i * distX * 1.5,
+  zIndex: total - i,
+});
+const placeNow = (el, slot, skew) =>
+  gsap.set(el, {
+    x: slot.x,
+    y: slot.y,
+    z: slot.z,
+    xPercent: -50,
+    yPercent: -50,
+    skewY: skew,
+    transformOrigin: "center center",
+    zIndex: slot.zIndex,
+    force3D: true,
+  });
+
+const CardSwap = ({
+  width = 500,
+  height = 400,
+  cardDistance = 60,
+  verticalDistance = 70,
+  delay = 5000,
+  pauseOnHover = false,
+  onCardClick,
+  skewAmount = 6,
+  easing = "elastic",
+  children,
+}) => {
+  const config =
+    easing === "elastic"
+      ? {
+        ease: "elastic.out(0.6,0.9)",
+        durDrop: 2,
+        durMove: 2,
+        durReturn: 2,
+        promoteOverlap: 0.9,
+        returnDelay: 0.05,
+      }
+      : {
+        ease: "power1.inOut",
+        durDrop: 0.8,
+        durMove: 0.8,
+        durReturn: 0.8,
+        promoteOverlap: 0.45,
+        returnDelay: 0.2,
+      };
+
+  const childArr = useMemo(
+    () => Children.toArray(children),
+    [children]
+  );
+  const refs = useMemo(
+    () => childArr.map(() => React.createRef()),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [childArr.length]
+  );
+
+  const order = useRef(
+    Array.from({ length: childArr.length }, (_, i) => i)
+  );
+
+  const tlRef = useRef(null);
+  const intervalRef = useRef();
+  const container = useRef(null);
+
+  useEffect(() => {
+    const total = refs.length;
+    refs.forEach((r, i) =>
+      placeNow(
+        r.current,
+        makeSlot(i, cardDistance, verticalDistance, total),
+        skewAmount
+      )
+    );
+
+    const swap = () => {
+      if (order.current.length < 2) return;
+
+      const [front, ...rest] = order.current;
+      const elFront = refs[front].current;
+      const tl = gsap.timeline();
+      tlRef.current = tl;
+
+      tl.to(elFront, {
+        y: "+=500",
+        duration: config.durDrop,
+        ease: config.ease,
+      });
+
+      tl.addLabel("promote", `-=${config.durDrop * config.promoteOverlap}`);
+      rest.forEach((idx, i) => {
+        const el = refs[idx].current;
+        const slot = makeSlot(i, cardDistance, verticalDistance, refs.length);
+        tl.set(el, { zIndex: slot.zIndex }, "promote");
+        tl.to(
+          el,
+          {
+            x: slot.x,
+            y: slot.y,
+            z: slot.z,
+            duration: config.durMove,
+            ease: config.ease,
+          },
+          `promote+=${i * 0.15}`
+        );
+      });
+
+      const backSlot = makeSlot(
+        refs.length - 1,
+        cardDistance,
+        verticalDistance,
+        refs.length
+      );
+      tl.addLabel("return", `promote+=${config.durMove * config.returnDelay}`);
+      tl.call(
+        () => {
+          gsap.set(elFront, { zIndex: backSlot.zIndex });
+        },
+        undefined,
+        "return"
+      );
+      tl.set(elFront, { x: backSlot.x, z: backSlot.z }, "return");
+      tl.to(
+        elFront,
+        {
+          y: backSlot.y,
+          duration: config.durReturn,
+          ease: config.ease,
+        },
+        "return"
+      );
+
+      tl.call(() => {
+        order.current = [...rest, front];
+      });
+    };
+
+    swap();
+    intervalRef.current = window.setInterval(swap, delay);
+
+    if (pauseOnHover) {
+      const node = container.current;
+      const pause = () => {
+        tlRef.current?.pause();
+        clearInterval(intervalRef.current);
+      };
+      const resume = () => {
+        tlRef.current?.play();
+        intervalRef.current = window.setInterval(swap, delay);
+      };
+      node.addEventListener("mouseenter", pause);
+      node.addEventListener("mouseleave", resume);
+      return () => {
+        node.removeEventListener("mouseenter", pause);
+        node.removeEventListener("mouseleave", resume);
+        clearInterval(intervalRef.current);
+      };
+    }
+    return () => clearInterval(intervalRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    cardDistance,
+    verticalDistance,
+    delay,
+    pauseOnHover,
+    skewAmount,
+    easing,
+  ]);
+
+  const rendered = childArr.map((child, i) =>
+    isValidElement(child)
+      ? cloneElement(child, {
+        key: i,
+        ref: refs[i],
+        style: { width, height, ...(child.props.style ?? {}) },
+        onClick: (e) => {
+          child.props.onClick?.(e);
+          onCardClick?.(i);
+        },
+      }) : child
+  );
+
+  return (
+    <div
+      ref={container}
+      className="card-swap-container"
+      style={{ width, height }}
+    >
+      {rendered}
+    </div>
+  );
+};
+
+export default CardSwap;


### PR DESCRIPTION
## Summary
- install `gsap` dependency
- create CardSwap component for animated card deck
- add About section showcasing card swap animation
- include styles for the new components
- render About section in App

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684dfb49507c83229ad8b6750ba225ce