### PR TITLE
Remove spacing between sections

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,5 +8,5 @@ main {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2rem;
+  gap: 0;
 }

--- a/src/components/About.css
+++ b/src/components/About.css
@@ -10,7 +10,7 @@
   width: 100%;
   min-height: 60vh;
   position: relative;
-  padding: 2rem 4rem;
+  padding: 0 4rem;
 }
 
 .about-title {

--- a/src/components/Courses.css
+++ b/src/components/Courses.css
@@ -1,6 +1,6 @@
 .courses {
   width: 100%;
-  padding: 2rem 0;
+  padding: 0;
 }
 
 .courses-title {

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -12,7 +12,7 @@
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
-  padding: 2rem 4rem;
+  padding: 0 4rem;
   text-align: left;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- eliminate default gap between main sections
- remove vertical padding from the Hero, About and Courses sections

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e20e56bb4832290ffa93ee350ba78