### PR TITLE
Add animated particles to About section

### DIFF
--- a/src/components/About.css
+++ b/src/components/About.css
@@ -11,6 +11,7 @@
   min-height: 60vh;
   position: relative;
   padding: 0 4rem;
+  overflow: hidden;
 }
 
 .about-title {

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,9 +1,11 @@
 import CardSwap, { Card } from './CardSwap.jsx'
+import ParticleBackground from './ParticleBackground.jsx'
 import './About.css'
 
 export default function About() {
   return (
     <section className="about" id="about">
+      <ParticleBackground />
       <h2 className="about-title">О нашей школе</h2>
       <p className="about-description">
         Наша школа программирования предоставляет современное образование, 

--- a/src/components/ParticleBackground.css
+++ b/src/components/ParticleBackground.css
@@ -1,0 +1,34 @@
+.particle-bg {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: -1;
+}
+
+.particle {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.4);
+  opacity: 0;
+  animation-name: particle-float;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+@keyframes particle-float {
+  0% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  90% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(-60px);
+    opacity: 0;
+  }
+}

--- a/src/components/ParticleBackground.jsx
+++ b/src/components/ParticleBackground.jsx
@@ -1,0 +1,35 @@
+import { useMemo } from 'react'
+import './ParticleBackground.css'
+
+export default function ParticleBackground({ count = 30 }) {
+  const particles = useMemo(
+    () =>
+      Array.from({ length: count }, () => ({
+        size: Math.random() * 4 + 2,
+        left: Math.random() * 100,
+        top: Math.random() * 100,
+        duration: Math.random() * 20 + 10,
+        delay: Math.random() * 20,
+      })),
+    [count]
+  )
+
+  return (
+    <div className="particle-bg">
+      {particles.map((p, i) => (
+        <span
+          key={i}
+          className="particle"
+          style={{
+            width: p.size,
+            height: p.size,
+            left: `${p.left}%`,
+            top: `${p.top}%`,
+            animationDuration: `${p.duration}s`,
+            animationDelay: `${p.delay}s`,
+          }}
+        />
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `ParticleBackground` component with randomised particle generation
- add particle background to About section
- hide overflow in About section CSS
- ensure particle animation styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e21f709dc8322b827d08743191777