### PR TITLE
Add magical rune particle effect

### DIFF
--- a/src/components/ParticleBackground.css
+++ b/src/components/ParticleBackground.css
@@ -8,17 +8,17 @@
 
 .particle {
   position: absolute;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.4);
   opacity: 0;
-  animation-name: particle-float;
+  pointer-events: none;
+  animation-name: rune-float;
   animation-timing-function: linear;
   animation-iteration-count: infinite;
+  text-shadow: 0 0 5px rgba(255, 215, 0, 0.7);
 }
 
-@keyframes particle-float {
+@keyframes rune-float {
   0% {
-    transform: translateY(0);
+    transform: translateY(0) rotate(0deg);
     opacity: 0;
   }
   10% {
@@ -28,7 +28,7 @@
     opacity: 1;
   }
   100% {
-    transform: translateY(-60px);
+    transform: translateY(-60px) rotate(360deg);
     opacity: 0;
   }
 }

--- a/src/components/ParticleBackground.jsx
+++ b/src/components/ParticleBackground.jsx
@@ -1,11 +1,17 @@
 import { useMemo } from 'react'
 import './ParticleBackground.css'
 
+const symbols = ['ᚱ', 'ᛟ', 'ᛞ', 'ᛁ', '{', '}', '<', '>', '0', '1', ';']
+const colors = ['#ffd700', '#ffa500', '#adff2f']
+
 export default function ParticleBackground({ count = 30 }) {
+
   const particles = useMemo(
     () =>
       Array.from({ length: count }, () => ({
-        size: Math.random() * 4 + 2,
+        size: Math.random() * 1.2 + 0.8,
+        symbol: symbols[Math.floor(Math.random() * symbols.length)],
+        color: colors[Math.floor(Math.random() * colors.length)],
         left: Math.random() * 100,
         top: Math.random() * 100,
         duration: Math.random() * 20 + 10,
@@ -21,14 +27,16 @@ export default function ParticleBackground({ count = 30 }) {
           key={i}
           className="particle"
           style={{
-            width: p.size,
-            height: p.size,
+            fontSize: `${p.size}rem`,
             left: `${p.left}%`,
             top: `${p.top}%`,
+            color: p.color,
             animationDuration: `${p.duration}s`,
             animationDelay: `${p.delay}s`,
           }}
-        />
+        >
+          {p.symbol}
+        </span>
       ))}
     </div>
   )


### PR DESCRIPTION
## Summary
- replace simple particle effect with fantasy-themed runes
- animate symbols with rotation and glow

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e246733608322983ddb3e8fa95f58